### PR TITLE
Implement basic SEO generator prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # WXY-1
+
+This project contains a simple prototype of an end-to-end SEO generator. It can generate basic HTML pages for a given topic using placeholder content.
+
+## Usage
+
+```bash
+python3 -m seo_generator.main <topic> --output <directory>
+```
+
+This will create a directory with generated HTML pages, a sitemap, and a log file.

--- a/seo_generator/__init__.py
+++ b/seo_generator/__init__.py
@@ -1,0 +1,7 @@
+"""SEO Generator package."""
+
+__version__ = "0.1.0"
+
+from .main import generate_site
+
+__all__ = ["generate_site"]

--- a/seo_generator/content_generator.py
+++ b/seo_generator/content_generator.py
@@ -1,0 +1,18 @@
+"""Content generation module (mock)."""
+from typing import List
+
+
+def generate_article(keyword: str) -> str:
+    """Generate a simple article about a keyword."""
+    paragraphs = [
+        f"<h1>{keyword.title()}</h1>",
+        f"<p>This article discusses {keyword} and how it can help you achieve your goals.</p>",
+        f"<p>We provide practical advice on {keyword} for beginners and experts alike.</p>",
+        f"<p>Stay tuned for more tips about {keyword}!</p>",
+    ]
+    return "\n".join(paragraphs)
+
+
+def generate_articles(keywords: List[str]) -> List[str]:
+    """Generate multiple articles."""
+    return [generate_article(k) for k in keywords]

--- a/seo_generator/keyword.py
+++ b/seo_generator/keyword.py
@@ -1,0 +1,12 @@
+"""Keyword research module (mock)."""
+from typing import List
+
+
+def fetch_keywords(topic: str) -> List[str]:
+    """Return a list of keywords based on a topic.
+
+    This mock implementation uses simple heuristics.
+    """
+    base = topic.lower().replace(" ", "-")
+    keywords = [f"{base}", f"best-{base}", f"{base}-guide", f"{base}-tips"]
+    return keywords

--- a/seo_generator/link_manager.py
+++ b/seo_generator/link_manager.py
@@ -1,0 +1,12 @@
+"""Link management utilities."""
+from typing import List
+from pathlib import Path
+
+
+def generate_sitemap(output_dir: Path, keywords: List[str]) -> None:
+    """Generate a simple sitemap.xml file."""
+    sitemap_entries = [
+        f"  <url><loc>{keyword}.html</loc></url>" for keyword in keywords
+    ]
+    content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" "<urlset>\n" + "\n".join(sitemap_entries) + "\n</urlset>"
+    (output_dir / "sitemap.xml").write_text(content, encoding="utf-8")

--- a/seo_generator/main.py
+++ b/seo_generator/main.py
@@ -1,0 +1,32 @@
+"""Main orchestration for SEO generator."""
+from pathlib import Path
+from typing import List
+
+from .keyword import fetch_keywords
+from .content_generator import generate_articles
+from .page_manager import save_pages
+from .link_manager import generate_sitemap
+from .monitor import log_generation
+
+
+def generate_site(topic: str, output_dir: str) -> List[str]:
+    """Generate a simple SEO site for the given topic."""
+    keywords = fetch_keywords(topic)
+    articles = generate_articles(keywords)
+    output_path = Path(output_dir)
+    save_pages(output_path, articles, keywords)
+    generate_sitemap(output_path, keywords)
+    log_generation(output_path, keywords)
+    return keywords
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a simple SEO site.")
+    parser.add_argument("topic", help="Topic to generate content for")
+    parser.add_argument("--output", default="site", help="Directory to output files")
+    args = parser.parse_args()
+
+    generate_site(args.topic, args.output)
+    print(f"Site generated in {args.output}")

--- a/seo_generator/monitor.py
+++ b/seo_generator/monitor.py
@@ -1,0 +1,10 @@
+"""Monitoring placeholder."""
+from pathlib import Path
+
+
+def log_generation(output_dir: Path, keywords):
+    """Log generated pages."""
+    log_file = output_dir / "log.txt"
+    with log_file.open("w", encoding="utf-8") as f:
+        for kw in keywords:
+            f.write(f"Generated page for {kw}\n")

--- a/seo_generator/page_manager.py
+++ b/seo_generator/page_manager.py
@@ -1,0 +1,28 @@
+"""Page management utilities."""
+from pathlib import Path
+from typing import Iterable
+
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\" />
+<title>{title}</title>
+<meta name=\"description\" content=\"{description}\" />
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def save_pages(output_dir: Path, articles: Iterable[str], keywords: Iterable[str]) -> None:
+    """Save articles to HTML files in output_dir."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for keyword, article in zip(keywords, articles):
+        title = keyword.title()
+        description = f"Learn about {keyword} in this article."
+        html = HTML_TEMPLATE.format(title=title, description=description, body=article)
+        filename = output_dir / f"{keyword}.html"
+        filename.write_text(html, encoding="utf-8")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,11 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from seo_generator import generate_site
+from pathlib import Path
+
+
+def test_generate_site(tmp_path: Path):
+    keywords = generate_site("demo topic", tmp_path)
+    assert (tmp_path / "demo-topic.html").exists()
+    assert (tmp_path / "sitemap.xml").exists()
+    assert (tmp_path / "log.txt").exists()
+    assert "demo-topic" in keywords[0]


### PR DESCRIPTION
## Summary
- add a minimal `seo_generator` package that can generate HTML articles, sitemap and logs
- add unit test for generation process
- update README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863556def088321be16a9ab95dfdbc8